### PR TITLE
Add API Documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
 			<artifactId>javafaker</artifactId>
 			<version>1.0.2</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/patina/codebloom/GlobalExceptionHandler.java
+++ b/src/main/java/com/patina/codebloom/GlobalExceptionHandler.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.server.ResponseStatusException;
 
-import com.patina.codebloom.common.dto.ApiResponse;
+import com.patina.codebloom.common.dto.ApiResponder;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
@@ -16,7 +16,7 @@ public class GlobalExceptionHandler {
         if (ex.getStatusCode() == HttpStatus.UNAUTHORIZED) {
             return ResponseEntity
                     .status(HttpStatus.UNAUTHORIZED)
-                    .body(ApiResponse.failure("You are not authorized"));
+                    .body(ApiResponder.failure("You are not authorized"));
         }
 
         return ResponseEntity

--- a/src/main/java/com/patina/codebloom/api/ApiController.java
+++ b/src/main/java/com/patina/codebloom/api/ApiController.java
@@ -5,17 +5,22 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.patina.codebloom.common.dto.ApiResponse;
+import com.patina.codebloom.common.dto.ApiResponder;
+import com.patina.codebloom.common.metadata.ServerMetadataObject;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 
 @RestController
 @RequestMapping("/api")
+@Tag(name = "Basic server metadata")
 public class ApiController {
 
+    @Operation(summary = "Basic metadata about the server")
     @GetMapping()
-    public ResponseEntity<ApiResponse<Void>> apiIndex(HttpServletRequest request) {
-        return ResponseEntity.ok().body(ApiResponse.success("Hello World!", null));
+    public ResponseEntity<ApiResponder<ServerMetadataObject>> apiIndex(HttpServletRequest request) {
+        return ResponseEntity.ok().body(ApiResponder.success("Hello from Codebloom!", new ServerMetadataObject()));
     }
 
 }

--- a/src/main/java/com/patina/codebloom/api/auth/AuthController.java
+++ b/src/main/java/com/patina/codebloom/api/auth/AuthController.java
@@ -1,5 +1,6 @@
 package com.patina.codebloom.api.auth;
 
+import org.springdoc.core.annotations.RouterOperation;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -10,14 +11,21 @@ import org.springframework.web.servlet.view.RedirectView;
 
 import com.patina.codebloom.common.db.models.Session;
 import com.patina.codebloom.common.db.repos.session.SessionRepository;
-import com.patina.codebloom.common.dto.ApiResponse;
+import com.patina.codebloom.common.dto.ApiResponder;
+import com.patina.codebloom.common.dto.autogen.__DO_NOT_USE_UNLESS_YOU_KNOW_WHAT_YOU_ARE_DOING_GENERIC_FAILURE_RESPONSE;
 import com.patina.codebloom.common.security.AuthenticationObject;
 import com.patina.codebloom.common.security.Protector;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 @RestController
+@Tag(name = "Authentication Routes")
 @RequestMapping("/api/auth")
 public class AuthController {
     private final SessionRepository sessionRepository;
@@ -28,13 +36,20 @@ public class AuthController {
         this.protector = protector;
     }
 
+    @Operation(summary = "Validate if the user is authenticated or not.", responses = {
+            @ApiResponse(responseCode = "200", description = "Authenticated"),
+            @ApiResponse(responseCode = "401", description = "Not authenticated", content = @Content(schema = @Schema(implementation = __DO_NOT_USE_UNLESS_YOU_KNOW_WHAT_YOU_ARE_DOING_GENERIC_FAILURE_RESPONSE.class)))
+    })
     @GetMapping("/validate")
-    public ResponseEntity<ApiResponse<AuthenticationObject>> validateAuth(HttpServletRequest request) {
+    public ResponseEntity<ApiResponder<AuthenticationObject>> validateAuth(HttpServletRequest request) {
         AuthenticationObject authenticationObject = protector.validateSession(request);
 
-        return ResponseEntity.ok().body(ApiResponse.success("You are authenticated!", authenticationObject));
+        return ResponseEntity.ok().body(ApiResponder.success("You are authenticated!", authenticationObject));
     }
 
+    @Operation(summary = "Logs user out", description = "Logs the user out if currently authenticated. This is a Redirect route that does redirects as responses.", responses = {
+            @ApiResponse(responseCode = "302", description = "Redirect to `/login?success=true&message=\"Successful logout message here.\"` on successful authentication.", content = @Content())
+    })
     // Decided to make this redirect to routes, with a message query if needed,
     // keeping it inline with the logic of the authentication handler.
     @GetMapping("/logout")

--- a/src/main/java/com/patina/codebloom/api/auth/CustomOpenApiAuthItems.java
+++ b/src/main/java/com/patina/codebloom/api/auth/CustomOpenApiAuthItems.java
@@ -1,0 +1,34 @@
+package com.patina.codebloom.api.auth;
+
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+
+/**
+ * These endpoints do not get automatically scanned and picked up by Springdoc,
+ * so they are manually entered.
+ */
+public class CustomOpenApiAuthItems {
+    public static PathItem discordOAuthFlow = new PathItem()
+            .get(new io.swagger.v3.oas.models.Operation()
+                    .addTagsItem("Authentication Routes")
+                    .summary("Start Discord OAuth authentication flow")
+                    .description(
+                            "Initiates the OAuth flow by redirecting the user to Discord for authentication. This is a Redirect route that does redirects as responses.")
+                    .responses(new ApiResponses()
+                            .addApiResponse("302", new ApiResponse()
+                                    .description("Redirect to Discord's authentication page"))));
+
+    public static PathItem discordOAuthFlowCallback = new PathItem()
+            .get(new io.swagger.v3.oas.models.Operation()
+                    .addTagsItem("Authentication Routes")
+                    .summary("Discord OAuth authentication flow callback")
+                    .description(
+                            "This route is the callback endpoint for the Discord OAuth authentication flow. Once the user successfully authenticates with Discord, they are redirected back to this endpoint where the server will then handle the authentication logic. This is a Redirect route that does redirects as responses.")
+                    .responses(new ApiResponses()
+                            .addApiResponse("302", new ApiResponse()
+                                    .description("Redirect to `/dashboard` on successful authentication."))
+                            .addApiResponse("302 ", new ApiResponse()
+                                    .description(
+                                            "Redirect to `/login?success=false&message=This is my message` on unsuccessful authentication."))));
+}

--- a/src/main/java/com/patina/codebloom/api/test/leaderboard/LeaderboardController.java
+++ b/src/main/java/com/patina/codebloom/api/test/leaderboard/LeaderboardController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.patina.codebloom.common.dto.ApiResponse;
+import com.patina.codebloom.common.dto.ApiResponder;
 import com.patina.codebloom.common.security.Protector;
 import com.patina.codebloom.common.test.TestLeaderboardList;
 import com.patina.codebloom.common.test.models.UserAndMetadata;
@@ -27,7 +27,7 @@ public class LeaderboardController {
     public ResponseEntity<?> getShallowLeaderboard() {
         ArrayList<UserAndMetadata> leaderboard = TestLeaderboardList.getTestDataShallowList();
 
-        return ResponseEntity.ok().body(ApiResponse.success("Leaderboard found!", leaderboard));
+        return ResponseEntity.ok().body(ApiResponder.success("Leaderboard found!", leaderboard));
     }
 
     @GetMapping("/all")
@@ -36,6 +36,6 @@ public class LeaderboardController {
 
         ArrayList<UserAndMetadata> leaderboard = TestLeaderboardList.getTestDataLongList();
 
-        return ResponseEntity.ok().body(ApiResponse.success("Leaderboard found!", leaderboard));
+        return ResponseEntity.ok().body(ApiResponder.success("Leaderboard found!", leaderboard));
     }
 }

--- a/src/main/java/com/patina/codebloom/common/dto/ApiResponder.java
+++ b/src/main/java/com/patina/codebloom/common/dto/ApiResponder.java
@@ -6,29 +6,29 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  * Use the generic methods for failure and success as they are simpler to use.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ApiResponse<T> {
+public class ApiResponder<T> {
     private boolean success;
     private T data;
     private String message;
 
-    private ApiResponse(boolean success, String message, T data) {
+    private ApiResponder(boolean success, String message, T data) {
         this.success = success;
         this.data = success ? data : null;
         this.message = message;
     };
 
-    private ApiResponse(boolean success, String message) {
+    private ApiResponder(boolean success, String message) {
         this.success = success;
         this.data = null;
         this.message = message;
     };
 
-    public static <T> ApiResponse<T> success(String message, T data) {
-        return new ApiResponse<>(true, message, data);
+    public static <T> ApiResponder<T> success(String message, T data) {
+        return new ApiResponder<>(true, message, data);
     }
 
-    public static <T> ApiResponse<T> failure(String message) {
-        return new ApiResponse<>(false, message, null);
+    public static <T> ApiResponder<T> failure(String message) {
+        return new ApiResponder<>(false, message, null);
     }
 
     public boolean isSuccess() {

--- a/src/main/java/com/patina/codebloom/common/dto/autogen/__DO_NOT_USE_UNLESS_YOU_KNOW_WHAT_YOU_ARE_DOING_GENERIC_FAILURE_RESPONSE.java
+++ b/src/main/java/com/patina/codebloom/common/dto/autogen/__DO_NOT_USE_UNLESS_YOU_KNOW_WHAT_YOU_ARE_DOING_GENERIC_FAILURE_RESPONSE.java
@@ -1,0 +1,17 @@
+package com.patina.codebloom.common.dto.autogen;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class __DO_NOT_USE_UNLESS_YOU_KNOW_WHAT_YOU_ARE_DOING_GENERIC_FAILURE_RESPONSE {
+    @Schema(defaultValue = "false")
+    private boolean success;
+    private String message;
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/patina/codebloom/common/metadata/ServerMetadataObject.java
+++ b/src/main/java/com/patina/codebloom/common/metadata/ServerMetadataObject.java
@@ -1,0 +1,51 @@
+package com.patina.codebloom.common.metadata;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class ServerMetadataObject {
+    private String name;
+    private String version;
+    private String description;
+    private ArrayList<String> authors;
+
+    public ServerMetadataObject() {
+        this.name = "Codebloom";
+        this.version = "v1.0.0";
+        this.description = "LeetCode leaderboard for Patina Network members to track progress and motivate each other.";
+        this.authors = new ArrayList<>(Arrays.asList("Alisha Zaman", "Alfardil Alam", "Michael Nunez", "Tahmid Ahmed"));
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public ArrayList<String> getAuthors() {
+        return authors;
+    }
+
+    public void setAuthors(ArrayList<String> authors) {
+        this.authors = authors;
+    }
+
+}

--- a/src/main/java/com/patina/codebloom/common/openapi/OpenApiConfig.java
+++ b/src/main/java/com/patina/codebloom/common/openapi/OpenApiConfig.java
@@ -1,0 +1,22 @@
+package com.patina.codebloom.common.openapi;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.patina.codebloom.api.auth.CustomOpenApiAuthItems;
+
+import io.swagger.v3.oas.models.OpenAPI;
+
+@Configuration
+public class OpenApiConfig {
+        @Bean
+        public OpenAPI customOpenAPI() {
+                OpenAPI openAPI = new OpenAPI();
+
+                openAPI.path("/api/auth/flow/discord", CustomOpenApiAuthItems.discordOAuthFlow);
+
+                openAPI.path("/api/auth/flow/callback/discord", CustomOpenApiAuthItems.discordOAuthFlowCallback);
+
+                return openAPI;
+        }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,5 +13,5 @@ spring.security.oauth2.client.provider.discord.token-uri=https://discord.com/api
 spring.security.oauth2.client.provider.discord.user-info-uri=https://discord.com/api/users/@me
 spring.security.oauth2.client.provider.discord.user-name-attribute=username
 
-springdoc.swagger-ui.enabled=${ENABLE_SWAGGER}
-springdoc.api-docs.enabled=${ENABLE_SWAGGER}
+springdoc.swagger-ui.enabled=${ENABLE_DOCUMENTATION}
+springdoc.api-docs.enabled=${ENABLE_DOCUMENTATION}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,6 @@ spring.security.oauth2.client.provider.discord.authorization-uri=https://discord
 spring.security.oauth2.client.provider.discord.token-uri=https://discord.com/api/oauth2/token
 spring.security.oauth2.client.provider.discord.user-info-uri=https://discord.com/api/users/@me
 spring.security.oauth2.client.provider.discord.user-name-attribute=username
+
+springdoc.swagger-ui.enabled=${ENABLE_SWAGGER}
+springdoc.api-docs.enabled=${ENABLE_SWAGGER}


### PR DESCRIPTION
  -  Implemented Springdoc to handle API documentation. 
  -  Renamed ApiResponse to ApiResponder to avoid namespace collision with swagger's ApiResponse. 
  - Added some custom API documentation for the OAuth routes that are abstracted off by Spring-Security.

Developers must add 
```env
ENABLE_DOCUMENTATION=true
```
to their `.env` files in order to enable the Swagger and OpenAPI endpoints. Once enabled (along with the development server running), developers may go to `/swagger-ui.html` to view the endpoint documentation.